### PR TITLE
feat: restore git diff display with file count

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,17 +107,15 @@ async function getGitChangesCached(): Promise<{
 		const combined = `${diff}\n${staged}`;
 
 		// 파일 수, insertions, deletions 추출
-		const files = (combined.match(/(\d+) file/g) || []).reduce(
-			(sum, m) => sum + Number.parseInt(m, 10),
-			0,
-		);
-		const insertions = (combined.match(/(\d+) insertion/g) || []).reduce(
-			(sum, m) => sum + Number.parseInt(m, 10),
-			0,
-		);
-		const deletions = (combined.match(/(\d+) deletion/g) || []).reduce(
-			(sum, m) => sum + Number.parseInt(m, 10),
-			0,
+		const [files, insertions, deletions] = [
+			/(\d+) file/g,
+			/(\d+) insertion/g,
+			/(\d+) deletion/g,
+		].map((regex) =>
+			(combined.match(regex) || []).reduce(
+				(sum, m) => sum + Number.parseInt(m, 10),
+				0,
+			),
 		);
 		cache.gitChanges = { files, insertions, deletions, timestamp: Date.now() };
 		return cache.gitChanges;
@@ -194,7 +192,10 @@ async function main() {
 	);
 
 	// 3번째 줄: git changes | PR URL
-	const hasGitChanges = gitChanges.files > 0 || gitChanges.insertions > 0 || gitChanges.deletions > 0;
+	const hasGitChanges =
+		gitChanges.files > 0 ||
+		gitChanges.insertions > 0 ||
+		gitChanges.deletions > 0;
 	if (hasGitChanges || prUrl) {
 		let line3 = "";
 		if (hasGitChanges) {


### PR DESCRIPTION
## Summary
- Claude Code 기본 statusbar의 git diff 표시 기능이 mode 활성화 시 보이지 않는 문제 해결
- 삭제되었던 git diff 기능 복원 + 파일 수 표시 추가
- 출력 형식: `✏️ {N} files +{insertions} -{deletions} | 📎 {PR URL}`

## Changes
- `gitChanges` 캐시 추가 (3초 TTL)
- `getGitChangesCached()` 함수 복원 (파일 수 포함)
- 3번째 줄에 git changes와 PR URL 조합 표시

## Test plan
- [ ] CC 재시작 후 git diff 정보 표시 확인
- [ ] mode 활성화 상태에서도 git diff 정보 표시 확인
- [ ] PR이 있을 때 `✏️ N files +X -Y | 📎 repo#123` 형식 확인

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)