### PR TITLE
docs: add i18n README and emoji guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cc-statusline
 
-[English](README.md) | [한국어](docs/README.ko.md) | [日本語](docs/README.ja.md) | [中文](docs/README.zh.md) | [Español](docs/README.es.md)
+English | [한국어](docs/README.ko.md) | [日本語](docs/README.ja.md) | [中文](docs/README.zh.md) | [Español](docs/README.es.md)
 
 Custom statusline for Claude Code.
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,6 +1,6 @@
 # cc-statusline
 
-[English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [中文](README.zh.md) | [Español](README.es.md)
+[English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [中文](README.zh.md) | Español
 
 Línea de estado personalizada para Claude Code.
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,6 +1,6 @@
 # cc-statusline
 
-[English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [中文](README.zh.md) | [Español](README.es.md)
+[English](../README.md) | [한국어](README.ko.md) | 日本語 | [中文](README.zh.md) | [Español](README.es.md)
 
 Claude Code用カスタムステータスライン。
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -1,6 +1,6 @@
 # cc-statusline
 
-[English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [中文](README.zh.md) | [Español](README.es.md)
+[English](../README.md) | 한국어 | [日本語](README.ja.md) | [中文](README.zh.md) | [Español](README.es.md)
 
 Claude Code를 위한 커스텀 상태표시줄.
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -1,6 +1,6 @@
 # cc-statusline
 
-[English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [中文](README.zh.md) | [Español](README.es.md)
+[English](../README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | 中文 | [Español](README.es.md)
 
 Claude Code 自定义状态栏。
 


### PR DESCRIPTION
## Summary
- Add language selector links to README (English, 한국어, 日本語, 中文, Español)
- Add Emoji Guide section explaining each statusline icon
- Create translated README files for Korean, Japanese, Chinese, and Spanish

## Files
- `README.md` - Added language links and emoji guide
- `docs/README.ko.md` - Korean translation
- `docs/README.ja.md` - Japanese translation
- `docs/README.zh.md` - Chinese translation
- `docs/README.es.md` - Spanish translation

## Test plan
- [ ] Verify language selector links work correctly
- [ ] Verify image paths render properly in translated READMEs
- [ ] Review translations for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)