### PR TITLE
fix: use dist/index.js as bin entry for bunx compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,11 @@
 		"typescript": "^5.9.3"
 	},
 	"bin": {
-		"cc-statusline": "src/index.ts"
+		"cc-statusline": "dist/index.js"
 	},
 	"description": "Custom statusline for Claude Code",
 	"files": [
-		"src/index.ts",
-		"src/lib.ts"
+		"dist/index.js"
 	],
 	"publishConfig": {
 		"registry": "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary
- `bin`을 `src/index.ts`에서 `dist/index.js`로 변경
- `files`를 `["dist/index.js"]`로 변경하여 빌드된 번들만 배포

## Problem
`bunx @say8425/cc-statusline` 실행 시 `Cannot find module './cli.ts'` 오류 발생. npm에 소스 일부만 포함되어 모듈 resolve 실패.

## Test plan
- [x] `bun build.ts` 후 `dist/index.js` 정상 실행 확인
- [ ] npm publish 후 `bunx @say8425/cc-statusline` 동작 확인

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)