### PR TITLE
fix: add build step before npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,5 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install -g npm@latest
       - run: bun install
+      - run: bun run build
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- CI release workflow에서 `npm publish` 전에 `bun run build` 단계 추가
- `dist/index.js`가 패키지에 포함되지 않던 문제 해결

## Problem
v2.0.1 배포 시 빌드 없이 publish되어 `dist/index.js`가 누락됨. `bunx @say8425/cc-statusline` 실행 불가.

## Test plan
- [ ] 다음 릴리스에서 `npm pack --dry-run`으로 `dist/index.js` 포함 확인
- [ ] `bunx @say8425/cc-statusline` 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)