### PR TITLE
fix: parse hex-encoded macOS Keychain credentials

### DIFF
--- a/src/__tests__/token.test.ts
+++ b/src/__tests__/token.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { parseCredentialString } from "../usage/token.ts";
+
+const VALID_JSON = '{"claudeAiOauth":{"accessToken":"tok"}}';
+
+describe("parseCredentialString", () => {
+	test("정상 JSON → accessToken 추출", () => {
+		expect(parseCredentialString(VALID_JSON)).toBe("tok");
+	});
+
+	test("hex-encoded JSON → accessToken 추출", () => {
+		const hex = Buffer.from(VALID_JSON, "utf-8").toString("hex");
+		expect(parseCredentialString(hex)).toBe("tok");
+	});
+
+	test("hex + binary prefix (\\x07) → accessToken 추출", () => {
+		const prefixed = `\x07${VALID_JSON}`;
+		const hex = Buffer.from(prefixed, "utf-8").toString("hex");
+		expect(parseCredentialString(hex)).toBe("tok");
+	});
+
+	test("claudeAiOauth key 없음 → null", () => {
+		expect(parseCredentialString('{"other":"data"}')).toBeNull();
+	});
+
+	test("빈 문자열 → null", () => {
+		expect(parseCredentialString("")).toBeNull();
+	});
+
+	test("공백만 있는 문자열 → null", () => {
+		expect(parseCredentialString("   ")).toBeNull();
+	});
+
+	test("잘못된 입력 (JSON도 hex도 아님) → null", () => {
+		expect(parseCredentialString("not-json-or-hex")).toBeNull();
+	});
+
+	test("앞뒤 공백 포함 JSON → accessToken 추출", () => {
+		expect(parseCredentialString(`  ${VALID_JSON}  `)).toBe("tok");
+	});
+
+	test("accessToken 필드 없음 → null", () => {
+		expect(
+			parseCredentialString('{"claudeAiOauth":{"refreshToken":"rt"}}'),
+		).toBeNull();
+	});
+});

--- a/src/usage/token.ts
+++ b/src/usage/token.ts
@@ -1,14 +1,52 @@
 import { $ } from "bun";
 import { CACHE_TTL, cache } from "../cache.ts";
 
+// 순수 함수: credential 문자열에서 accessToken 추출
+export function parseCredentialString(raw: string): string | null {
+	let text = raw.trim();
+	if (text.length === 0) return null;
+
+	// macOS security -w outputs hex when password has non-printable chars
+	if (/^[0-9a-fA-F]+$/.test(text) && text.length > 0) {
+		text = Buffer.from(text, "hex").toString("utf-8");
+	}
+
+	// 1) 표준 JSON 파싱 시도
+	try {
+		const creds = JSON.parse(text);
+		return creds?.claudeAiOauth?.accessToken ?? null;
+	} catch {}
+
+	// 2) Binary prefix 포맷: brace-matching으로 내부 JSON 추출
+	const keyIdx = text.indexOf('"claudeAiOauth"');
+	if (keyIdx < 0) return null;
+
+	const braceStart = text.indexOf("{", keyIdx);
+	if (braceStart < 0) return null;
+
+	let depth = 0;
+	for (let i = braceStart; i < text.length; i++) {
+		if (text[i] === "{") depth++;
+		else if (text[i] === "}") depth--;
+		if (depth === 0) {
+			try {
+				const inner = JSON.parse(text.substring(braceStart, i + 1));
+				return inner?.accessToken ?? null;
+			} catch {
+				return null;
+			}
+		}
+	}
+	return null;
+}
+
 // macOS Keychain에서 OAuth access token 읽기
 export async function getAccessToken(): Promise<string | null> {
 	if (process.platform !== "darwin") return null;
 	try {
 		const result =
 			await $`security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null`.text();
-		const creds = JSON.parse(result);
-		return creds?.claudeAiOauth?.accessToken ?? null;
+		return parseCredentialString(result);
 	} catch {
 		return null;
 	}

--- a/src/usage/token.ts
+++ b/src/usage/token.ts
@@ -7,7 +7,12 @@ export function parseCredentialString(raw: string): string | null {
 	if (text.length === 0) return null;
 
 	// macOS security -w outputs hex when password has non-printable chars
-	if (/^[0-9a-fA-F]+$/.test(text) && text.length > 0) {
+	// Require even length and min length to avoid false positives (e.g. "face")
+	if (
+		text.length > 10 &&
+		text.length % 2 === 0 &&
+		/^[0-9a-fA-F]+$/.test(text)
+	) {
 		text = Buffer.from(text, "hex").toString("utf-8");
 	}
 


### PR DESCRIPTION
## Summary
- macOS `security find-generic-password -w`가 non-printable 문자(`\x07` prefix) 포함 시 hex 문자열로 출력하여 `JSON.parse()` 실패 → `--show-usage` usage 줄 미표시
- `parseCredentialString()` 순수 함수 추출: hex 감지 → 디코딩 → JSON 파싱, binary prefix 시 brace-matching fallback
- 9개 테스트 케이스 추가 (`token.test.ts`)

Closes #37

## Test plan
- [x] `bun test` 전체 106개 통과
- [x] 수동 테스트: `--show-usage` 시 3번째 줄(⏳/📊/⏰/📅) 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)