### PR TITLE
feat: use workspace.git_worktree and context_window.used_percentage from JSON input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ cc-statusline/
 | Git 브랜치 | `git branch --show-current` |
 | Git diff | `git diff --shortstat` |
 | PR URL | `gh pr view` |
-| 메인 프로젝트명 | `workspace.git_worktree` (2.1.98+) → `git rev-parse --git-common-dir` (폴백) |
+| 메인 프로젝트명 | `git rev-parse --git-common-dir` (워크트리) |
 | 블록 사용량 | stdin `rate_limits.five_hour.used_percentage` |
 | 리셋 타이머 | stdin `rate_limits.five_hour.resets_at` |
 | 주간 사용량 | stdin `rate_limits.seven_day.used_percentage` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,11 +47,11 @@ cc-statusline/
 | 세션 시간 | `cost.total_duration_ms` |
 | 세션 비용 | `cost.total_cost_usd` |
 | Context 토큰 | `context_window.current_usage.*` |
-| Context % | `current_usage / context_window_size` |
+| Context % | `context_window.used_percentage` (없으면 미표시) |
 | Git 브랜치 | `git branch --show-current` |
 | Git diff | `git diff --shortstat` |
 | PR URL | `gh pr view` |
-| 메인 프로젝트명 | `git rev-parse --git-common-dir` (워크트리) |
+| 메인 프로젝트명 | `workspace.git_worktree` (2.1.98+) → `git rev-parse --git-common-dir` (폴백) |
 | 블록 사용량 | stdin `rate_limits.five_hour.used_percentage` |
 | 리셋 타이머 | stdin `rate_limits.five_hour.resets_at` |
 | 주간 사용량 | stdin `rate_limits.seven_day.used_percentage` |

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -70,7 +70,9 @@ describe("main function (integration)", () => {
 		}
 	});
 
-	test("main function accepts workspace.git_worktree field in input", async () => {
+	test("main function does not crash on unknown workspace fields like git_worktree", async () => {
+		// workspace.git_worktree is a forward-compat field (Claude Code 2.1.98+)
+		// currently declared in the type schema but not consumed by any logic
 		const testInput = JSON.stringify({
 			cost: { total_duration_ms: 0, total_cost_usd: 0 },
 			context_window: {
@@ -104,9 +106,8 @@ describe("main function (integration)", () => {
 		try {
 			await main();
 
-			// Should not throw and should output at least 2 lines
+			// Should not throw; output still produced
 			expect(logs.length).toBeGreaterThanOrEqual(2);
-			expect(logs[0]).toContain("project");
 		} finally {
 			// @ts-expect-error - restoring stdin
 			Bun.stdin.stream = originalStream;

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -70,6 +70,91 @@ describe("main function (integration)", () => {
 		}
 	});
 
+	test("main function accepts workspace.git_worktree field in input", async () => {
+		const testInput = JSON.stringify({
+			cost: { total_duration_ms: 0, total_cost_usd: 0 },
+			context_window: {
+				context_window_size: 200000,
+				current_usage: {
+					input_tokens: 0,
+					output_tokens: 0,
+					cache_creation_input_tokens: 0,
+					cache_read_input_tokens: 0,
+				},
+			},
+			workspace: {
+				project_dir: "/test/project",
+				current_dir: "/test/project",
+				git_worktree: "rosy-thimble",
+			},
+		});
+
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(encoder.encode(testInput));
+				controller.close();
+			},
+		});
+
+		const originalStream = Bun.stdin.stream;
+		// @ts-expect-error - mocking stdin
+		Bun.stdin.stream = () => stream;
+
+		try {
+			await main();
+
+			// Should not throw and should output at least 2 lines
+			expect(logs.length).toBeGreaterThanOrEqual(2);
+			expect(logs[0]).toContain("project");
+		} finally {
+			// @ts-expect-error - restoring stdin
+			Bun.stdin.stream = originalStream;
+		}
+	});
+
+	test("main function uses used_percentage from context_window", async () => {
+		const testInput = JSON.stringify({
+			cost: { total_duration_ms: 3600000, total_cost_usd: 0.5 },
+			context_window: {
+				context_window_size: 200000,
+				used_percentage: 42,
+				current_usage: {
+					input_tokens: 50000,
+					output_tokens: 10000,
+					cache_creation_input_tokens: 5000,
+					cache_read_input_tokens: 2000,
+				},
+			},
+			workspace: {
+				project_dir: "/test/project",
+				current_dir: "/test/project",
+			},
+		});
+
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(encoder.encode(testInput));
+				controller.close();
+			},
+		});
+
+		const originalStream = Bun.stdin.stream;
+		// @ts-expect-error - mocking stdin
+		Bun.stdin.stream = () => stream;
+
+		try {
+			await main();
+
+			// Should use pre-calculated 42% instead of manual calculation (34%)
+			expect(logs[1]).toContain("42%");
+		} finally {
+			// @ts-expect-error - restoring stdin
+			Bun.stdin.stream = originalStream;
+		}
+	});
+
 	test("main function shows usage when rate_limits is provided in stdin", async () => {
 		const testInput = JSON.stringify({
 			cost: { total_duration_ms: 0, total_cost_usd: 0 },

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -15,6 +15,7 @@ function createClaudeInput(
 		},
 		context_window: {
 			context_window_size: 200000,
+			used_percentage: 34,
 			current_usage: {
 				input_tokens: 50000,
 				output_tokens: 10000,
@@ -153,12 +154,82 @@ describe("renderStatusLine", () => {
 		});
 	});
 
+	describe("used_percentage from JSON", () => {
+		test("shows context segment when used_percentage is provided", () => {
+			const ctx = createRenderContext({
+				fullClaudeJson: {
+					cost: { total_duration_ms: 0, total_cost_usd: 0 },
+					context_window: {
+						context_window_size: 200000,
+						used_percentage: 42,
+						current_usage: {
+							input_tokens: 50000,
+							output_tokens: 10000,
+							cache_creation_input_tokens: 5000,
+							cache_read_input_tokens: 2000,
+						},
+					},
+					workspace: { project_dir: "/test", current_dir: "/test" },
+				},
+			});
+			const lines = renderStatusLine(ctx);
+
+			expect(lines[1]).toContain("🧠");
+			expect(lines[1]).toContain("42%");
+		});
+
+		test("omits context segment when used_percentage is absent", () => {
+			const ctx = createRenderContext({
+				fullClaudeJson: {
+					cost: { total_duration_ms: 0, total_cost_usd: 0 },
+					context_window: {
+						context_window_size: 200000,
+						current_usage: {
+							input_tokens: 50000,
+							output_tokens: 10000,
+							cache_creation_input_tokens: 5000,
+							cache_read_input_tokens: 2000,
+						},
+					},
+					workspace: { project_dir: "/test", current_dir: "/test" },
+				},
+			});
+			const lines = renderStatusLine(ctx);
+
+			expect(lines[1]).not.toContain("🧠");
+			expect(lines[1]).not.toContain("%");
+		});
+
+		test("omits context segment when used_percentage is null", () => {
+			const ctx = createRenderContext({
+				fullClaudeJson: {
+					cost: { total_duration_ms: 0, total_cost_usd: 0 },
+					context_window: {
+						context_window_size: 200000,
+						used_percentage: null as unknown as number,
+						current_usage: {
+							input_tokens: 100000,
+							output_tokens: 0,
+							cache_creation_input_tokens: 0,
+							cache_read_input_tokens: 0,
+						},
+					},
+					workspace: { project_dir: "/test", current_dir: "/test" },
+				},
+			});
+			const lines = renderStatusLine(ctx);
+
+			expect(lines[1]).not.toContain("🧠");
+		});
+	});
+
 	describe("context usage colors", () => {
 		test("uses WHITE for low usage (< 50%)", () => {
 			const ctx = createRenderContext({
 				claudeJson: {
 					context_window: {
 						context_window_size: 200000,
+						used_percentage: 20,
 						current_usage: {
 							input_tokens: 40000,
 							output_tokens: 0,
@@ -170,7 +241,6 @@ describe("renderStatusLine", () => {
 			});
 			const lines = renderStatusLine(ctx);
 
-			// 40000 / 200000 = 20%
 			expect(lines[1]).toContain(C.WHITE);
 			expect(lines[1]).toContain("20%");
 		});
@@ -180,6 +250,7 @@ describe("renderStatusLine", () => {
 				claudeJson: {
 					context_window: {
 						context_window_size: 200000,
+						used_percentage: 60,
 						current_usage: {
 							input_tokens: 120000,
 							output_tokens: 0,
@@ -191,7 +262,6 @@ describe("renderStatusLine", () => {
 			});
 			const lines = renderStatusLine(ctx);
 
-			// 120000 / 200000 = 60%
 			expect(lines[1]).toContain(C.YELLOW);
 			expect(lines[1]).toContain("60%");
 		});
@@ -201,6 +271,7 @@ describe("renderStatusLine", () => {
 				claudeJson: {
 					context_window: {
 						context_window_size: 200000,
+						used_percentage: 90,
 						current_usage: {
 							input_tokens: 180000,
 							output_tokens: 0,
@@ -212,7 +283,6 @@ describe("renderStatusLine", () => {
 			});
 			const lines = renderStatusLine(ctx);
 
-			// 180000 / 200000 = 90%
 			expect(lines[1]).toContain(C.RED);
 			expect(lines[1]).toContain("90%");
 		});
@@ -540,7 +610,8 @@ describe("renderStatusLine", () => {
 			});
 
 			const lines = renderStatusLine(ctx);
-			expect(lines[1]).toContain("0 (0%)");
+			// used_percentage가 없으므로 context 세그먼트 표시 안 함
+			expect(lines[1]).not.toContain("🧠");
 		});
 
 		test("handles null rateLimits", () => {

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -200,6 +200,30 @@ describe("renderStatusLine", () => {
 			expect(lines[1]).not.toContain("%");
 		});
 
+		test("shows context segment when used_percentage is 0", () => {
+			// Guard against `!usedPercentage` truthy-check regression
+			const ctx = createRenderContext({
+				fullClaudeJson: {
+					cost: { total_duration_ms: 0, total_cost_usd: 0 },
+					context_window: {
+						context_window_size: 200000,
+						used_percentage: 0,
+						current_usage: {
+							input_tokens: 0,
+							output_tokens: 0,
+							cache_creation_input_tokens: 0,
+							cache_read_input_tokens: 0,
+						},
+					},
+					workspace: { project_dir: "/test", current_dir: "/test" },
+				},
+			});
+			const lines = renderStatusLine(ctx);
+
+			expect(lines[1]).toContain("🧠");
+			expect(lines[1]).toContain("0 (0%)");
+		});
+
 		test("omits context segment when used_percentage is null", () => {
 			const ctx = createRenderContext({
 				fullClaudeJson: {

--- a/src/render.ts
+++ b/src/render.ts
@@ -18,20 +18,6 @@ export function renderStatusLine(ctx: RenderContext): string[] {
 	// 3. 비용
 	const costUsd = ctx.claudeJson.cost?.total_cost_usd || 0;
 
-	// 4. Context 토큰 및 사용률 (used_percentage가 없으면 표시 안 함)
-	const usage = ctx.claudeJson.context_window?.current_usage;
-	const usedPercentage = ctx.claudeJson.context_window?.used_percentage;
-	const hasContextInfo = usedPercentage != null;
-
-	const totalTokens = usage
-		? usage.input_tokens +
-			usage.output_tokens +
-			usage.cache_creation_input_tokens +
-			usage.cache_read_input_tokens
-		: 0;
-	const contextPct = hasContextInfo ? Math.round(usedPercentage) : 0;
-	const ctxColor = getUsageColor(contextPct);
-
 	// 1번째 줄: 폴더 | 워크트리 | 브랜치
 	let line1: string;
 	if (ctx.mainProjectName) {
@@ -49,7 +35,17 @@ export function renderStatusLine(ctx: RenderContext): string[] {
 	let line2 =
 		`${C.WHITE}⏱️ ${formatTime(sessionHrs, sessionMins)}${C.RESET}` +
 		` | ${C.WHITE}💰 $${costUsd.toFixed(2)}${C.RESET}`;
-	if (hasContextInfo) {
+	const usedPercentage = ctx.claudeJson.context_window?.used_percentage;
+	if (usedPercentage != null) {
+		const usage = ctx.claudeJson.context_window?.current_usage;
+		const totalTokens = usage
+			? usage.input_tokens +
+				usage.output_tokens +
+				usage.cache_creation_input_tokens +
+				usage.cache_read_input_tokens
+			: 0;
+		const contextPct = Math.round(usedPercentage);
+		const ctxColor = getUsageColor(contextPct);
 		line2 += ` | ${ctxColor}🧠 ${formatNumber(totalTokens)} (${contextPct}%)${C.RESET}`;
 	}
 	lines.push(line2);

--- a/src/render.ts
+++ b/src/render.ts
@@ -18,10 +18,10 @@ export function renderStatusLine(ctx: RenderContext): string[] {
 	// 3. 비용
 	const costUsd = ctx.claudeJson.cost?.total_cost_usd || 0;
 
-	// 4. Context 토큰 계산
+	// 4. Context 토큰 및 사용률 (used_percentage가 없으면 표시 안 함)
 	const usage = ctx.claudeJson.context_window?.current_usage;
-	const contextSize =
-		ctx.claudeJson.context_window?.context_window_size || 200000;
+	const usedPercentage = ctx.claudeJson.context_window?.used_percentage;
+	const hasContextInfo = usedPercentage != null;
 
 	const totalTokens = usage
 		? usage.input_tokens +
@@ -29,8 +29,7 @@ export function renderStatusLine(ctx: RenderContext): string[] {
 			usage.cache_creation_input_tokens +
 			usage.cache_read_input_tokens
 		: 0;
-
-	const contextPct = Math.round((totalTokens / contextSize) * 100);
+	const contextPct = hasContextInfo ? Math.round(usedPercentage) : 0;
 	const ctxColor = getUsageColor(contextPct);
 
 	// 1번째 줄: 폴더 | 워크트리 | 브랜치
@@ -46,11 +45,13 @@ export function renderStatusLine(ctx: RenderContext): string[] {
 	}
 	lines.push(line1);
 
-	// 2번째 줄: 세션 시간 | 비용 | 컨텍스트
-	const line2 =
+	// 2번째 줄: 세션 시간 | 비용 | 컨텍스트 (used_percentage가 있을 때만)
+	let line2 =
 		`${C.WHITE}⏱️ ${formatTime(sessionHrs, sessionMins)}${C.RESET}` +
-		` | ${C.WHITE}💰 $${costUsd.toFixed(2)}${C.RESET}` +
-		` | ${ctxColor}🧠 ${formatNumber(totalTokens)} (${contextPct}%)${C.RESET}`;
+		` | ${C.WHITE}💰 $${costUsd.toFixed(2)}${C.RESET}`;
+	if (hasContextInfo) {
+		line2 += ` | ${ctxColor}🧠 ${formatNumber(totalTokens)} (${contextPct}%)${C.RESET}`;
+	}
 	lines.push(line2);
 
 	// 3번째 줄: 리셋 타이머 | 5시간 사용량 | 7일 사용량 (rate_limits가 있을 때)

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,9 @@ export interface ClaudeStatusInput {
 	workspace: {
 		current_dir: string;
 		project_dir: string;
+		// Claude Code 2.1.98+ — linked git worktree name. Declared for type
+		// completeness; main project name is still derived via git_rev-parse
+		// because this field carries a name, not a path.
 		git_worktree?: string;
 	};
 	rate_limits?: RateLimits;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface ClaudeStatusInput {
 	};
 	context_window: {
 		context_window_size: number;
+		used_percentage?: number;
 		current_usage: {
 			input_tokens: number;
 			output_tokens: number;
@@ -28,6 +29,7 @@ export interface ClaudeStatusInput {
 	workspace: {
 		current_dir: string;
 		project_dir: string;
+		git_worktree?: string;
 	};
 	rate_limits?: RateLimits;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface ClaudeStatusInput {
 		current_dir: string;
 		project_dir: string;
 		// Claude Code 2.1.98+ — linked git worktree name. Declared for type
-		// completeness; main project name is still derived via git_rev-parse
+		// completeness; main project name is still derived via git rev-parse
 		// because this field carries a name, not a path.
 		git_worktree?: string;
 	};


### PR DESCRIPTION
## Summary

Claude Code 2.1.98에서 `workspace.git_worktree` 필드가 JSON input에 추가되었고, `context_window.used_percentage` 필드도 공식적으로 제공됩니다. 두 필드를 스키마에 추가하고 `used_percentage`를 컨텍스트 사용률 표시에 활용합니다.

## Changes

- **`types.ts`**: `workspace.git_worktree?: string`, `context_window.used_percentage?: number` 추가
- **`render.ts`**: `used_percentage`가 제공되면 컨텍스트 세그먼트(🧠)를 표시하고, 없으면 생략 (수동 계산 폴백 제거)
- **테스트**: `used_percentage` 사용/미제공/null 케이스 및 `git_worktree` 필드 수용 테스트 추가
- **`CLAUDE.md`**: 데이터 소스 테이블 업데이트

## Rationale

- Anthropic이 공식 계산한 `used_percentage`는 실제 컨텍스트 상태를 더 정확하게 반영 (문서: _"use this for accurate context percentage since it reflects the actual context state"_)
- 수동 계산은 캐시 토큰 집계 방식에 따라 공식값과 오차가 생길 수 있음
- `used_percentage`가 null인 경우(세션 초반, 첫 API 호출 전)에는 부정확한 값을 보여주기보다 해당 세그먼트를 숨기는 편이 낫다고 판단

## Notes

- `workspace.git_worktree`는 문서상 워크트리 **이름**(예: `"feature-xyz"`)이고 메인 프로젝트 경로가 아니므로, 기존 `getMainProjectNameCached()`(`git rev-parse --git-common-dir` 기반) 로직은 그대로 유지합니다. 향후 활용 여지는 있지만 이 PR 범위 밖입니다.

Closes #42

## Test plan

- [x] `bun test` — 83 pass / 0 fail
- [x] `npm run build` 성공
- [x] 수동 테스트: `used_percentage: 42` 입력 시 `🧠 67,000 (42%)` 표시 확인
- [x] 수동 테스트: `used_percentage` 없을 때 🧠 세그먼트 생략 확인