### PR TITLE
chore: upgrade dev dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,12 @@ bun test --coverage
 
 **커버리지**: 함수 100%, 라인 97%+
 
+### 릴리스
+
+[릴리스 가이드](docs/RELEASE_GUIDE.md) 참조. release-please + Conventional Commits 기반 자동 릴리스.
+- `fix:` → patch, `feat:` → minor, `feat!:` / `BREAKING CHANGE:` → major
+- `chore`, `docs`, `test`, `ci` 등은 릴리스를 트리거하지 않음
+
 ### 수정 시 주의사항
 
 - 300ms마다 실행되므로 성능 중요

--- a/bun.lock
+++ b/bun.lock
@@ -4,38 +4,38 @@
     "": {
       "name": "cc-statusline",
       "devDependencies": {
-        "@biomejs/biome": "^2.3.9",
-        "@types/bun": "latest",
-        "typescript": "^5.9.3",
+        "@biomejs/biome": "^2.4.11",
+        "@types/bun": "^1.3.12",
+        "typescript": "^6.0.2",
       },
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.3.9", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.9", "@biomejs/cli-darwin-x64": "2.3.9", "@biomejs/cli-linux-arm64": "2.3.9", "@biomejs/cli-linux-arm64-musl": "2.3.9", "@biomejs/cli-linux-x64": "2.3.9", "@biomejs/cli-linux-x64-musl": "2.3.9", "@biomejs/cli-win32-arm64": "2.3.9", "@biomejs/cli-win32-x64": "2.3.9" }, "bin": { "biome": "bin/biome" } }, "sha512-js+34KpnY65I00k8P71RH0Uh2rJk4BrpxMGM5m2nBfM9XTlKE5N1URn5ydILPRyXXq4ebhKCjsvR+txS+D4z2A=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.11", "@biomejs/cli-darwin-x64": "2.4.11", "@biomejs/cli-linux-arm64": "2.4.11", "@biomejs/cli-linux-arm64-musl": "2.4.11", "@biomejs/cli-linux-x64": "2.4.11", "@biomejs/cli-linux-x64-musl": "2.4.11", "@biomejs/cli-win32-arm64": "2.4.11", "@biomejs/cli-win32-x64": "2.4.11" }, "bin": { "biome": "bin/biome" } }, "sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-hHbYYnna/WBwem5iCpssQQLtm5ey8ADuDT8N2zqosk6LVWimlEuUnPy6Mbzgu4GWVriyL5ijWd+1zphX6ll4/A=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-sKMW5fpvGDmPdqCchtVH5MVlbVeSU3ad4CuKS45x8VHt3tNSC8CZ2QbxffAOKYK9v/mAeUiPC6Cx6+wtyU1q7g=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-BXBB6HbAgZI6T6QB8q6NSwIapVngqArP6K78BqkMerht7YjL6yWctqfeTnJm0qGF2bKBYFexslrbV+VTlM2E6g=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-JOHyG2nl8XDpncbMazm1uBSi1dPX9VbQDOjKcfSVXTqajD0PsgodMOKyuZ/PkBu5Lw877sWMTGKfEfpM7jE7Cw=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-PjYuv2WLmvf0WtidxAkFjlElsn0P6qcvfPijrqu1j+3GoW3XSQh3ywGu7gZ25J25zrYj3KEovUjvUZB55ATrGw=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-FUkb/5beCIC2trpqAbW9e095X4vamdlju80c1ExSmhfdrojLZnWkah/XfTSixKb/dQzbAjpD7vvs6rWkJ+P07Q=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-w48Yh/XbYHO2cBw8B5laK3vCAEKuocX5ItGXVDAqFE7Ze2wnR00/1vkY6GXglfRDOjWHu2XtxI0WKQ52x1qxEA=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-90+J63VT7qImy9s3pkWL0ZX27VzVwMNCRzpLpe5yMzMYPbO1vcjL/w/Q5f/juAGMvP7a2Fd0H7IhAR6F7/i78A=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
 
-    "@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/node": ["@types/node@25.0.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-czWPzKIAXucn9PtsttxmumiQ9N0ok9FrBwgRWrwmVLlp86BrMExzvXRLFYRJ+Ex3g6yqj+KuaxfX1JTgV2lpfg=="],
 
-    "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }

--- a/docs/RELEASE_GUIDE.md
+++ b/docs/RELEASE_GUIDE.md
@@ -1,0 +1,86 @@
+# Release Guide
+
+이 프로젝트는 [release-please](https://github.com/googleapis/release-please)를 사용하여 버전 관리 및 릴리스를 자동화합니다.
+
+## 동작 방식
+
+1. main 브랜치에 커밋이 푸시되면 release-please가 자동으로 실행
+2. [Conventional Commits](https://www.conventionalcommits.org/) 기반으로 버전 범프 결정
+3. Release PR이 자동 생성 (CHANGELOG.md, package.json 버전 업데이트)
+4. Release PR이 머지되면 GitHub Release + npm publish 자동 실행
+
+## 커밋 메시지와 버전 범프
+
+release-please는 커밋 메시지의 **type**으로 버전을 결정합니다.
+
+### 릴리스를 트리거하는 타입
+
+| 커밋 메시지 | 버전 범프 | 예시 |
+|------------|----------|------|
+| `fix: ...` | patch (x.x.**1**) | `fix: handle null rate_limits` |
+| `feat: ...` | minor (x.**1**.0) | `feat: add weekly usage display` |
+| `feat!: ...` | **major** (**1**.0.0) | `feat!: upgrade TypeScript to v6` |
+| `fix!: ...` | **major** (**1**.0.0) | `fix!: change rate_limits format` |
+| `refactor!: ...` | **major** (**1**.0.0) | `refactor!: restructure JSON input` |
+
+### 릴리스를 트리거하지 않는 타입
+
+| 타입 | 용도 |
+|------|------|
+| `chore` | 유지보수 (의존성 업데이트 등) |
+| `docs` | 문서 변경 |
+| `test` | 테스트 추가/수정 |
+| `ci` | CI/CD 설정 변경 |
+| `refactor` | 코드 리팩토링 (breaking 아닌 경우) |
+| `perf` | 성능 개선 |
+
+### Breaking Change (Major 버전 범프)
+
+Major 버전을 올리려면 두 가지 방법이 있습니다:
+
+**방법 1: `!` 접미사 사용**
+```
+feat!: change input format
+
+description here
+```
+
+**방법 2: BREAKING CHANGE footer 사용**
+```
+feat: change input format
+
+BREAKING CHANGE: rate_limits field renamed to usage_limits
+```
+
+두 방법 모두 major 버전을 트리거합니다.
+
+## 워크플로우 구성
+
+`.github/workflows/release.yml`에 정의되어 있습니다:
+
+- **release-please job**: Release PR 생성 및 자동 머지 설정
+- **publish job**: Release 생성 시 `bun build` → `npm publish --provenance` 실행
+- **트리거**: main 브랜치 push 또는 수동 실행 (workflow_dispatch)
+
+## 릴리스 절차
+
+### 일반 릴리스
+
+1. feature 브랜치에서 작업 후 PR 생성
+2. PR 머지 → main에 커밋 푸시
+3. release-please가 자동으로 Release PR 생성
+4. Release PR이 자동 머지됨 (`--auto --rebase`)
+5. npm에 자동 배포
+
+### 수동 릴리스 트리거
+
+Actions 탭에서 Release 워크플로우를 수동 실행할 수 있습니다:
+```
+GitHub → Actions → Release → Run workflow
+```
+
+## 참고
+
+- release-please 공식 문서: https://github.com/googleapis/release-please
+- Conventional Commits 스펙: https://www.conventionalcommits.org
+- release-please 설정 옵션: https://github.com/googleapis/release-please/blob/main/docs/customizing.md

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
 		"url": "https://github.com/say8425/cc-statusline.git"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.3.9",
-		"@types/bun": "latest",
-		"typescript": "^5.9.3"
+		"@biomejs/biome": "^2.4.11",
+		"@types/bun": "^1.3.12",
+		"typescript": "^6.0.2"
 	},
 	"bin": {
 		"cc-statusline": "dist/index.js"


### PR DESCRIPTION
## Summary

- `@biomejs/biome`: 2.3.9 → 2.4.11 (minor)
- `@types/bun`: 1.3.4 → 1.3.12 (patch)
- `typescript`: 5.9.3 → 6.0.2 (major)

## Test plan
- [x] `bun run typecheck` — pass
- [x] `bun run lint` — pass (22 files, no issues)
- [x] `bun test` — 84 tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)